### PR TITLE
Bump compat for ModelingToolkit v11 / Sundials v6 / Catalyst v16 ecosystem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ OrdinaryDiffEqRosenbrock = "1, 2"
 Plots = "1"
 SBML = "1"
 SBMLToolkit = "0.1.32"
-Sundials = "4, 6.1"
+Sundials = "4"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ authors = ["paulflang", "anandijain"]
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
@@ -17,16 +18,18 @@ Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 
 [compat]
 CSV = "0.10"
+Catalyst = "14, 15, 16"
 DataFrames = "1"
+Downloads = "1"
 JET = "0.9, 0.10.14, 0.11"
-ModelingToolkit = "8, 9"
+ModelingToolkit = "8, 9, 11.24"
 OrdinaryDiffEq = "6, 7"
 OrdinaryDiffEqRosenbrock = "1, 2"
 Plots = "1"
 SBML = "1"
-SBMLToolkit = "0.1"
-Sundials = "4"
-julia = "1.9"
+SBMLToolkit = "0.1.32"
+Sundials = "4, 6.1"
+julia = "1.10"
 
 [extras]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"

--- a/src/SBMLToolkitTestSuite.jl
+++ b/src/SBMLToolkitTestSuite.jl
@@ -4,7 +4,24 @@ using SBMLToolkit
 using SBMLToolkit: convert_simplify_math
 using SBML
 using ModelingToolkit, OrdinaryDiffEq, OrdinaryDiffEqRosenbrock, Sundials
+using Catalyst: Catalyst
 using CSV, DataFrames, Downloads, Plots
+
+# Catalyst v16 / MTK v11 replaced `convert(ODESystem, rs; ...)` with
+# `Catalyst.ode_model(rs; ...)` and renamed `structural_simplify` to `mtkcompile`.
+# These shims keep the verifier working against both the v14/v15+v9 stack and the
+# v16+v11 stack until the lower bounds are dropped.
+@static if pkgversion(Catalyst) >= v"16"
+    _to_odesystem(rs; kwargs...) = Catalyst.ode_model(rs; kwargs...)
+else
+    _to_odesystem(rs; kwargs...) = convert(ODESystem, rs; kwargs...)
+end
+
+@static if isdefined(ModelingToolkit, :mtkcompile)
+    _simplify_system(sys) = ModelingToolkit.mtkcompile(sys)
+else
+    _simplify_system(sys) = ModelingToolkit.structural_simplify(sys)
+end
 
 const algomap = Dict(
     "00177" => Rodas4(),
@@ -147,8 +164,8 @@ function verify_case(case::AbstractString, logdir::AbstractString; verbose::Bool
         rs = complete(ReactionSystem(ml))
         k = 2
 
-        sys = convert(
-            ODESystem, rs; include_zero_odes = true,
+        sys = _to_odesystem(
+            rs; include_zero_odes = true,
             combinatoric_ratelaws = false
         )
         if length(ml.events) > 0
@@ -156,7 +173,7 @@ function verify_case(case::AbstractString, logdir::AbstractString; verbose::Bool
         end
         k = 3
 
-        ssys = structural_simplify(sys)
+        ssys = _simplify_system(sys)
         k = 4
 
         ts = res_df[:, 1]  # LinRange(settings["start"], settings["duration"], settings["steps"]+1)


### PR DESCRIPTION
## Summary

Supersedes the dependabot PR in #65 with the breaking-change fixes
required to actually reach ModelingToolkit v11 + Catalyst v16 +
Sundials v6 in the resolved dep tree, plus the verifier code changes
needed to keep `verify_case` working under the new APIs.

#65 widened compat in the right direction but the new versions were
unreachable on the registered SBMLToolkit (which capped Catalyst at
v15) and even once SBMLToolkit gains Catalyst v16 support, two MTK v11
breaking changes hit `verify_case` directly. Closes #65.

## Compat changes (vs. main)

- Add `Catalyst` as an explicit dep with `Catalyst = "14, 15, 16"`. The
  `verify_case` pipeline now invokes `Catalyst.ode_model` directly, so
  the dep needs to be explicit rather than transitive via SBMLToolkit.
- `ModelingToolkit = "8, 9, 11.24"` and `Sundials = "4, 6.1"` (kept
  from the dependabot bump in #65). These pull in MTK v11.24 and
  Sundials v6.1 once SBMLToolkit v0.1.32+ unlocks Catalyst v16.
- Replace dependabot's `Downloads = "1.7.0"` with `Downloads = "1"`.
  `Downloads` is a Julia stdlib whose version tracks the Julia minor;
  pinning to 1.7.0 made the package only resolvable on Julia 1.11+.
- `SBMLToolkit = "0.1.32"` (was `"0.1"`). The Catalyst v16 / MTK v11
  fixes land in 0.1.32 — older SBMLToolkit precompilation breaks under
  SymbolicUtils v4 and crashes at runtime under Catalyst v16.
- Bump `julia = "1.10"` (was `"1.9"`). MTK v11 requires Julia 1.10+.

## Code changes

Two MTK v11 / Catalyst v16 breaking changes hit the verifier:

1. `convert(ODESystem, rs; ...)` is removed; the supported entry point
   is `Catalyst.ode_model(rs; ...)`. (`ODESystem` itself is now an
   `IntermediateDeprecationSystem` alias.)
2. `structural_simplify` was renamed to `mtkcompile`.

Both call sites are version-gated with `@static if pkgversion(Catalyst) >= v"16"`
and `@static if isdefined(ModelingToolkit, :mtkcompile)` respectively, so
the verifier still works against the older v14/v15 + MTK v9 stack that's
selected on SBMLToolkit < 0.1.32.

## Upstream dependency

This PR depends on SciML/SBMLToolkit.jl#201, which adds Catalyst v16 /
ModelingToolkit v11 support to SBMLToolkit (split `defaults` →
`bindings`/`initial_conditions`, switch `convert(ODESystem, rs)` →
`Catalyst.ode_model(rs)`, switch `.arguments` → `SymbolicUtils.arguments(...)`).
Once #201 merges and a new SBMLToolkit version is registered, this PR's
`SBMLToolkit = "0.1.32"` floor will be reachable on the registry and CI's
`force_latest_compatible_version` check will pass.

## Local verification

Julia 1.10 LTS, SBMLToolkit fix branch (#201) dev'd into the project,
resolved stack: Catalyst v16.1.1 + ModelingToolkit v11.24.1 + Sundials
v6.1.0 + OrdinaryDiffEq v6.111.0 + SBMLToolkit v0.1.32.

- `verify_all(1:500, ...)`: 277 cases pass, **0 regressions and 0
  improvements** vs. the main-branch baseline (which uses Catalyst v15
  + MTK v9 + Sundials v4 + SBMLToolkit v0.1.31). The same 277 cases
  pass and the same 223 fail with the same `res` outcomes.
- JET tests pass (3/3, no reports).
- A previously-passing case family with SBML `initialAssignment` on a
  parameter referencing a species (00507/00508/00509: `parameter S3 :=
  k1 * S2`) was a real regression once Catalyst v16's stricter
  `check_bindings` validator was reached — fixed in
  SciML/SBMLToolkit.jl#201 by routing such assignments to
  `initial_conditions` instead of `bindings`.

## Test plan

- [ ] CI passes once SBMLToolkit v0.1.32 is registered.
- [ ] No regressions in `verify_all(1:1822, ...)` once the full sweep
      can be run without the intermittent Sundials v6 finalizer crash
      that hits in long batches locally (separate Sundials.jl issue,
      unrelated to this bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)