### PR TITLE
Bump Sundials compat to allow v6.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ OrdinaryDiffEqRosenbrock = "1, 2"
 Plots = "1"
 SBML = "1"
 SBMLToolkit = "0.1.32"
-Sundials = "4"
+Sundials = "4, 6.1"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ OrdinaryDiffEqRosenbrock = "1, 2"
 Plots = "1"
 SBML = "1"
 SBMLToolkit = "0.1.32"
-Sundials = "4, 6.1"
+Sundials = "4, 5, 6.1"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary

Bumps the Sundials compat from `\"4\"` to `\"4, 6.1\"`. This is the
remaining half of the original dependabot bump (#65); the MTK v11 /
Catalyst v16 / SBMLToolkit v0.1.32 portion landed in #66 with Sundials
capped at v4 because the Sundials.jl wrapper hit two crashes during
verification:

- Local sweep (Julia 1.10 LTS, full 1822-case run): heap corruption
  inside KINSOL finalization (`free(): invalid next size (fast)`
  triggered from `KINFree` during Julia GC).
- Prior CI attempt on #66 (Julia 1.12): runner lost communication with
  the server during the test step, consistent with a Sundials segfault
  inside `initialize_dae!`.

Both crashes are inside the Sundials.jl wrapper / native lib and are
independent of the SBMLToolkit / MTK / Catalyst changes that already
shipped in #66 (which then ran the suite green on Sundials v4).

Re-arming the v6 bump now to surface the wrapper instability upstream.
If CI passes, great — the bump lands. If it crashes again the failure
mode is clearly localized to Sundials and can be filed against
SciML/Sundials.jl.

## Test plan
- [ ] CI Julia 1 - ubuntu-latest passes the full 1822-case sweep with
      Sundials v6.1 resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)