### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,56 +4,9 @@ on:
   - pull_request
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-    steps:
-      - uses: actions/checkout@v6
-
-      # Download previous test results
-      - name: Download previous test results
-        id: download_results
-        uses: actions/download-artifact@v4
-        with:
-          name: previous_results
-          path: test/logs
-        continue-on-error: true
-
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-
-      # Upload current test results and summary
-      - uses: actions/upload-artifact@v6
-        if: failure() || success()
-        with:
-          name: test_logs
-          path: test/logs
-
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          file: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    name: "Tests"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "1"
+      julia-arch: "x64"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,22 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+      - main
+    paths-ignore:
+      - 'docs/**'
+jobs:
+  downgrade:
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts all CI workflows to the centralized `SciML/.github` reusable workflows (pinned `@v1`, `secrets: "inherit"` on every caller), matching the Sundials.jl end-state.

## Converted (inline -> central)
- **CI.yml**: inline tests -> `tests.yml@v1` (preserved `julia-version: 1`, `julia-arch: x64`)
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos` -> `spellcheck.yml@v1`

## Added
- **Downgrade.yml** -> `downgrade.yml@v1` (`julia-version: lts`, `skip: Pkg,TOML`) — no downgrade workflow existed before.

## Cleanup
- Removed the `crate-ci/typos` ignore from `dependabot.yml` (the centralized spellcheck workflow now pins the typos version). `github-actions` (weekly, `/`) and `julia` (daily, dirs `/` + `/test`, group all-julia-packages) blocks preserved.

## Checks
- Runic: ran `Runic.main(["--inplace","."])` locally, rc=0, no formatting changes (repo was already Runic-clean from the prior inline check).
- Typos: `typos .` exits 0; no fixes needed. `.typos.toml` left unchanged.

## Notes / issues
- The old `CI.yml` had repo-specific steps that the centralized `tests.yml@v1` does **not** reproduce: (1) `actions/download-artifact`/`upload-artifact` of `test/logs` for previous/current test-result logging, and (2) `codecov-action` with `fail_ci_if_error: true` + explicit `CODECOV_TOKEN`. The centralized workflow handles coverage/codecov its own way and drops the custom test-log artifact plumbing. If the test-log artifact behavior is needed, it must be kept in a separate (non-centralized) workflow step. Flagging for review.
- No `docs/` directory -> no Documentation caller. No existing Downstream/Benchmark/CompatHelper workflows -> none added/removed. TagBot.yml left unchanged.
- **Branch protection**: check names change (e.g. job names become "Tests", "Runic Format Check", "Spell Check with Typos", "Downgrade Tests"). Any required-status-check rules will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)