### PR TITLE
Use SciMLTesting v1.2 (folder-based run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,8 @@ OrdinaryDiffEqRosenbrock = "1, 2"
 Plots = "1"
 SBML = "1"
 SBMLToolkit = "0.1.32"
-SafeTestsets = "0.1"
+SafeTestsets = "0.1, 1"
+SciMLTesting = "1"
 Sundials = "4, 5, 6.1"
 Test = "1"
 julia = "1.10"
@@ -37,9 +38,9 @@ julia = "1.10"
 [extras]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["JET", "JSON", "Pkg", "SafeTestsets", "Test"]
+test = ["JET", "JSON", "SafeTestsets", "SciMLTesting", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SBMLToolkitTestSuite = "792e603a-1588-414c-b272-614011baa40e"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -8,5 +10,7 @@ SBMLToolkitTestSuite = {path = "../.."}
 
 [compat]
 JET = "0.9, 0.10.14, 0.11"
+SafeTestsets = "0.0.1, 0.1, 1"
+SciMLTesting = "1"
 Test = "1"
 julia = "1.10"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,21 +1,2 @@
-using SafeTestsets, Test
-
-const GROUP = get(ENV, "GROUP", "All")
-
-if GROUP == "All" || GROUP == "Core"
-    @safetestset "SBML Test Suite" begin
-        include("sbmltestsuite.jl")
-    end
-end
-
-if GROUP == "QA"
-    using Pkg
-    Pkg.activate(joinpath(@__DIR__, "qa"))
-    Pkg.develop(path = joinpath(@__DIR__, ".."))
-    Pkg.instantiate()
-    include(joinpath(@__DIR__, "qa", "qa.jl"))
-elseif GROUP == "All"
-    @safetestset "JET static analysis" begin
-        include(joinpath("qa", "qa.jl"))
-    end
-end
+using SciMLTesting
+run_tests()


### PR DESCRIPTION
Converts the test harness to the SciMLTesting v1.2 folder-based `run_tests()` model.

- `test/runtests.jl` is now just `using SciMLTesting; run_tests()` (folder-discovery mode).
- **Core** = top-level `test/*.jl` (`sbmltestsuite.jl`), run in the main test env.
- **QA** = `test/qa/` (`qa.jl` + its sub-env `Project.toml`), run in its own isolated environment.
- `test/test_groups.toml` is unchanged; the Core/QA semantics are derived from the folder layout.
- Test deps: added `SciMLTesting` (compat `1`) and bumped `SafeTestsets` compat to `0.1, 1` in the root `[extras]`/`[targets].test`/`[compat]`; dropped `Pkg` (the v1.2 harness owns all `Pkg` operations — no remaining `Pkg` use in `test/`). Added `SciMLTesting` + `SafeTestsets` + `Test` to `test/qa/Project.toml`.

The exact set of tests run under each `GROUP` value is unchanged (behavior-preserving). Verified end-to-end locally with `GROUP=QA` (exercises the sub-env activation path) on Julia 1.11.

Supersedes the prior v1.0.0 explicit-args rollout on this branch.

Ignore until reviewed by @ChrisRackauckas.
